### PR TITLE
[Add]bookmark

### DIFF
--- a/app/assets/javascripts/public/bookmarks.coffee
+++ b/app/assets/javascripts/public/bookmarks.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/public/bookmarks.scss
+++ b/app/assets/stylesheets/public/bookmarks.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/bookmarks controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/public/bookmarks_controller.rb
+++ b/app/controllers/public/bookmarks_controller.rb
@@ -1,0 +1,16 @@
+class Public::BookmarksController < ApplicationController
+
+  def create
+    post = Post.find(params[:post_id])
+    bookmark = current_user.bookmarks.new(post_id: post.id)
+    bookmark.save
+    redirect_to post_path(post)
+  end
+
+  def destroy
+    post = Post.find(params[:post_id])
+    bookmark = current_user.bookmarks.find_by(post_id: post.id)
+    bookmark.destroy
+    redirect_to post_path(post)
+  end
+end

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -35,6 +35,10 @@ class Public::PostsController < ApplicationController
       render "edit"
     end
   end
+  
+  def bookmarks
+    @posts = current_user.bookmark_posts.includes(:user).order(created_at: :desc)
+  end
 
   private
 

--- a/app/helpers/public/bookmarks_helper.rb
+++ b/app/helpers/public/bookmarks_helper.rb
@@ -1,0 +1,2 @@
+module Public::BookmarksHelper
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,5 @@
+class Bookmark < ApplicationRecord
+  
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,13 @@ class Post < ApplicationRecord
   belongs_to :genre
   belongs_to :user, dependent: :destroy
   has_many :post_comments, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmark_posts, through: :bookmarks, source: :post
+
+  def bookmarked_by?(user)
+    bookmarks.where(user_id: user.id).exists?
+  end
+
 
   validates :genre_id, presence: true
   validates :reference_url, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :post_comments, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmark_posts, through: :bookmarks, source: :post
   has_many :follower_of_relationships, class_name: "Relationship", foreign_key:"follower_id", dependent: :destroy
   has_many :followings, through: :follower_of_relationships, source: :followed
   has_many :followed_of_relationships, class_name: "Relationship", foreign_key:"followed_id", dependent: :destroy

--- a/app/views/public/bookmarks/_bookmark_form.html.erb
+++ b/app/views/public/bookmarks/_bookmark_form.html.erb
@@ -1,0 +1,11 @@
+<% if post.bookmarked_by?(current_user) %>
+  <p>
+    <%= link_to "ブックマークを外す",post_bookmark_path(post), method: :delete, class: 'btn btn-danger btn-sm' %>
+    <%= post.bookmarks.count %>
+  </p>
+  <% else %>
+  <p>
+    <%= link_to "ブックマーク登録",post_bookmarks_path(post), method: :post, class: 'btn btn-primary btn-sm' %>
+    <%= post.bookmarks.count %>
+  </p>
+<% end %>

--- a/app/views/public/bookmarks/create.js.erb
+++ b/app/views/public/bookmarks/create.js.erb
@@ -1,0 +1,3 @@
+<!--$(".bookmark_form").html("<%#= escape_javascript(render partial: 'public/bookmarks/bookmark_form',locals: {post: @post}) %>");-->
+
+$(".bookmark_form_<%= @post.id %>").html("<%= escape_javascript(render partial: 'public/bookmarks/bookmark_form',locals: {post: @post}) %>");

--- a/app/views/public/bookmarks/destroy.js.erb
+++ b/app/views/public/bookmarks/destroy.js.erb
@@ -1,0 +1,3 @@
+<!--$(".bookmark_form").html("<%#= escape_javascript(render partial: 'public/bookmarks/bookmark_form',locals: {post: @post}) %>");-->
+
+$(".bookmark_form_<%= @post.id %>").html("<%= escape_javascript(render partial: 'public/bookmarks/bookmark_form',locals: {post: @post}) %>");

--- a/app/views/public/post_comments/_comment.html.erb
+++ b/app/views/public/post_comments/_comment.html.erb
@@ -3,7 +3,7 @@
     <% post.post_comments.each do |post_comment| %>
       <div>
         <%= link_to user_path(post_comment.user_id),remote: true do %>
-          <%= attachment_image_tag post_comment.user, :profile_image, :fill, 50, 50, fallback: "no-image-icon.jpg" %>
+          <%= attachment_image_tag post_comment.user, :profile_image, fallback: "no_image.jpg", size: "50x50" %>
         <% end %>
         <%= post_comment.comment %>
         <% if post_comment.user == current_user %>

--- a/app/views/public/posts/bookmarks.html.erb
+++ b/app/views/public/posts/bookmarks.html.erb
@@ -1,0 +1,55 @@
+<div class="container_field">
+  <div class="row ml-5">
+    <div class="col-md-2">
+      <%= render 'public/users/info', user: current_user %>
+    </div>
+    <div class= "col-md-9">
+      <div class='row my-1'>
+        <div class='col-md-5'>
+          <h5 class="offset-md-1 bg-light text-center"><%= current_user.name %>様のブックマーク一覧</h5>
+        </div>
+      </div>
+      <div class='row mx-2'>
+        <div class='col-md-12'>
+          <table class='table table-hover table-inverse'>
+            <thead class='table-secondary'>
+              <tr>
+                <!--scopeのサイズ調整ができていない-->
+                <th scope="col-md-2">記事投稿者</th>
+                <th scope="col-md-1">投稿日時</th>
+                <th scope="col-md-6">タイトル</th>
+                <th scope="col-md-1"></th>
+                <th scope="col-md-2">ブックマーク数</th>
+              </tr>
+            </thead>
+            <tbody>
+              <!--非公開記事について自分のは見れるように、他人のはみれないように-->
+              <% @posts.each do |post| %>
+                <tr id="post_<%= post.id %>">
+                  <td>
+                    <%= link_to user_path(post.user) do %>
+                      <%= attachment_image_tag post.user, :profile_image, fallback: "no_image.jpg", size:'60x50' %>
+                    <% end %>
+                  </td>
+                  <td><%= post.created_at %></td>
+                  <td><%= link_to post.title, post_path(post.id), class: "post_#{post.id}" %></td>
+                  <td>
+                    <% if post.release == true %>
+                      <p class="text-success font-weight-bold">公開</p>
+                    <% elsif post.release == false %>
+                      <p class="text-secondary font-weight-bold">非公開</p>
+                    <% end %>
+                  </td>
+                  <td><%= post.bookmarks.count %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+          <ul class="pagination justify-content-center">
+            <%#= paginate @posts %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -8,6 +8,9 @@
         <div class="col-md-2 text-center">
           <h5 class="bg-light" >記事詳細</h5>
         </div>
+          <td class="bookmark_form_<%= @post.id %>">
+            <%= render 'public/bookmarks/bookmark_form', post: @post %>
+          </td>
       </div>
       <div class="row offset-md-2 mb-2">
         <div class="col-md-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   }
 
   root to: 'public/homes#top'
-  # get 'search', to: 'searches/search'
+  get 'search', to: 'searches#search'
 
   scope module: :public do
     resources :users, only: [:edit, :update, :show] do
@@ -25,9 +25,7 @@ Rails.application.routes.draw do
     end
 
     resources :posts, except: [:index, :destroy] do
-      collection do
-        get 'bookmarks'
-      end
+      get :bookmarks, on: :collection
       resources :bookmarks, only: [:create, :destroy]
       resources :post_comments, only: [:create, :destroy]
     end

--- a/db/migrate/20211013120727_create_bookmarks.rb
+++ b/db/migrate/20211013120727_create_bookmarks.rb
@@ -1,0 +1,11 @@
+class CreateBookmarks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :bookmarks do |t|
+      
+      t.integer :user_id
+      t.integer :post_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_12_093358) do
+ActiveRecord::Schema.define(version: 2021_10_13_120727) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -22,6 +22,13 @@ ActiveRecord::Schema.define(version: 2021_10_12_093358) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "genres", force: :cascade do |t|

--- a/test/controllers/public/bookmarks_controller_test.rb
+++ b/test/controllers/public/bookmarks_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Public::BookmarksControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/bookmarks.yml
+++ b/test/fixtures/bookmarks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BookmarkTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
・ブックマーク機能の追加。ブックマークした記事の一覧のビューも作成

※記事詳細にブックマークの登録、解除ボタンとカウントは出るようにした。非同期通信で実装を試みたがリロードしないと情報が更新されなかったので一旦は非同期通信は保留。
ブックマーク一覧（カレントユーザーの情報しかとって来れていないのでどうにかしたい）

※昨日gitにpushしてからの作業と本日の19時までの作業はcloud9のインスタンスを誤って終了してしまったことにより全て無かったことに。改めてcloud9の環境を作成して昨夜までの作業分をcloneして作業したが追いつかず。インスタンスは終了ではなく停止であることに注意。それとやはり一日一回はgitにpushするようにしたい。