### PR TITLE
[Fix]bookmarks

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -36,10 +36,6 @@ class Public::PostsController < ApplicationController
     end
   end
 
-  def bookmarks
-    @posts = current_user.bookmark_posts.includes(:user).order(created_at: :desc)
-  end
-
   private
 
   def post_params

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -28,6 +28,11 @@ class Public::UsersController < ApplicationController
     # フラッシュメッセージの表示がされていない。
     redirect_to root_path
   end
+  
+  def bookmarks
+    @user = User.find(params[:user_id])
+    @posts = @user.bookmark_posts.includes(:user).order(created_at: :desc)
+  end
 
   private
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,7 +3,6 @@ class Post < ApplicationRecord
   belongs_to :user, dependent: :destroy
   has_many :post_comments, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
-  has_many :bookmark_posts, through: :bookmarks, source: :post
   has_many :bookmarked_users, through: :bookmarks, source: :user
   
 

--- a/app/views/public/bookmarks/_bookmark_form.html.erb
+++ b/app/views/public/bookmarks/_bookmark_form.html.erb
@@ -1,6 +1,6 @@
 <% if post.bookmarked_by?(current_user) %>
   <p>
-    <%= link_to "unbookmark",post_bookmark_path(post), method: :delete, class: 'btn btn-danger btn-sm' %>
+    <%= link_to "unbookmark",post_bookmarks_path(post), method: :delete, class: 'btn btn-danger btn-sm' %>
     <%= post.bookmarks.count %>
   </p>
   <% else %>

--- a/app/views/public/users/_index.html.erb
+++ b/app/views/public/users/_index.html.erb
@@ -16,7 +16,7 @@
         <td>
           <% if current_user != user %>
             <% if current_user.following?(user) %>
-             <%= link_to "フォローを外す", user_relationship_path(user.id), method: :delete %>
+             <%= link_to "フォローを外す", user_relationships_path(user.id), method: :delete %>
             <% else %>
              <%= link_to "フォローする", user_relationships_path(user.id), method: :post %>
             <% end %>

--- a/app/views/public/users/_info.html.erb
+++ b/app/views/public/users/_info.html.erb
@@ -40,7 +40,7 @@
   <% if user.id == current_user.id %>
     <%= link_to '編集する',edit_user_path(user),class: "btn btn-success btn-block" %>
   <% elsif current_user.following?(user) %>
-   <%= link_to "フォローを外す", user_relationship_path(user.id), method: :delete,class: "btn btn-primary btn-block" %>
+   <%= link_to "フォローを外す", user_relationships_path(user.id), method: :delete,class: "btn btn-primary btn-block" %>
   <% else %>
    <%= link_to "フォローする", user_relationships_path(user.id), method: :post,class: "btn btn-success btn-block" %>
   <% end %>  

--- a/app/views/public/users/bookmarks.html.erb
+++ b/app/views/public/users/bookmarks.html.erb
@@ -1,12 +1,12 @@
 <div class="container_field">
   <div class="row ml-5">
     <div class="col-md-2">
-      <%= render 'public/users/info', user: current_user %>
+      <%= render 'public/users/info', user: @user %>
     </div>
     <div class= "col-md-9">
       <div class='row my-1'>
         <div class='col-md-5'>
-          <h5 class="offset-md-1 bg-light text-center"><%= current_user.name %>様のブックマーク一覧</h5>
+          <h5 class="offset-md-1 bg-light text-center"><%= @user.name %>様のブックマーク一覧</h5>
         </div>
       </div>
       <div class='row mx-2'>
@@ -32,7 +32,8 @@
                     <% end %>
                   </td>
                   <td><%= l post.created_at %></td>
-                  <td><%= link_to post.title, post_path(post.id), class: "post_#{post.id}" %></td>
+                  <td class="text-truncate" style="max-width: 300px;"><%= link_to post.title, post_path(post.id), class: "post_#{post.id}" %></td>
+                  <!--tdにclass="text-truncate"を指定することでstyle="max-width: 300px;"の範囲内での文字列を省略-->
                   <td>
                     <% if post.release == true %>
                       <p class="text-success font-weight-bold">公開</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,14 +20,14 @@ Rails.application.routes.draw do
         get 'confirm'
         patch 'withdraw'
       end
-      resources :relationships, only: [:create, :destroy] 
+      get :bookmarks
+      resource :relationships, only: [:create, :destroy]
       get 'followings', to: 'relationships#followings', as: 'followings'
       get 'followers', to: 'relationships#followers', as: 'followers'
     end
 
     resources :posts, except: [:index, :destroy] do
-      get :bookmarks, on: :collection
-      resources :bookmarks, only: [:create, :destroy]
+      resource :bookmarks, only: [:create, :destroy]
       resources :post_comments, only: [:create, :destroy]
     end
   end


### PR DESCRIPTION
・10/13にやり残していた「ブックマーク一覧（カレントユーザーの情報しかとって来れていないのでどうにかしたい）」の修正。
bookmarksのネストをpostsからusersに変更し、user_idをもたせたことで解消。これに伴ってuser、postのモデルやコントローラーの記述も修正。
・td要素での文字列の省略