### PR TITLE
[Improve]ja.yml ヘッダーの記述他

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -90,3 +90,19 @@ main {
   font-size: 32px;
   text-decoration: none;
 }
+
+.genre-table {
+  width:150px;
+  border-collapse: collapse;
+  border: solid 2px orange;
+  background: #fff5e5;
+}
+
+.genre-table th {
+  text-align: center;
+  border: solid 1px orange;
+}
+
+.genre-table td {
+  font-weight: bold;
+}

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -4,9 +4,7 @@ class Public::HomesController < ApplicationController
     @genres = Genre.all
     # showable -> { joins(:user).where(release: true, users: {is_deleted: false }) }
     @new_posts = Post.includes(:genre).showable.limit(4).order(created_at: :desc)
-    @post_ranks = Post.includes(:genre, :user).showable.limit(4).sort do |a, b|
-      b.bookmarked_users.size <=> a.bookmarked_users.size
-    end
+    @post_ranks = Post.showable.includes(:user, :genre).left_joins(:bookmarks).group(:id).order('count(post_id) desc').limit(4)
   end
 
   def about; end

--- a/app/controllers/public/relationships_controller.rb
+++ b/app/controllers/public/relationships_controller.rb
@@ -11,12 +11,12 @@ class Public::RelationshipsController < ApplicationController
   end
 
   def followings
-    user = User.find(params[:user_id])
-    @users = user.followings
+    @user = User.find(params[:user_id])
+    @users = @user.followings
   end
 
   def followers
-    user = User.find(params[:user_id])
-    @users = user.followers
+    @user = User.find(params[:user_id])
+    @users = @user.followers
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
-  belongs_to :genre
+  # 独自のバリデーションメッセージを表示させるためにデフォルトのバリデーションを無効に。
+  belongs_to :genre, optional: true
   belongs_to :user, dependent: :destroy
   has_many :post_comments, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
@@ -10,13 +11,19 @@ class Post < ApplicationRecord
     bookmarks.where(user_id: user.id).exists?
   end
 
-  validates :genre_id, presence: true
   validates :reference_url, presence: true
   validates :title, presence: true
   validates :body, presence: true
+  validate :check_genre
 
   # search,homesコントローラーの表記短縮のため記述
   scope :showable, -> { joins(:user).where(release: true, users: {is_deleted: false }) }
+
+  def check_genre
+    if self.genre_id.blank?
+      errors[:genre] << "を選択してください"
+    end
+  end
 
   def create_notification_by(current_user)
     notification = current_user.active_notifications.new(

--- a/app/views/layouts/_admin_signed_in_bar.html.erb
+++ b/app/views/layouts/_admin_signed_in_bar.html.erb
@@ -1,0 +1,3 @@
+<li><%= link_to "ジャンル一覧", admin_genres_path,class: 'nav-link active' %></li>
+<li><%= link_to "会員一覧", admin_root_path,class: 'nav-link active' %></li>
+<li><%= link_to "ログアウト", destroy_admin_session_path,class: 'nav-link active', method: :delete %></li>

--- a/app/views/layouts/_user_signed_in_bar.html.erb
+++ b/app/views/layouts/_user_signed_in_bar.html.erb
@@ -1,0 +1,28 @@
+<li>
+  <%= link_to user_path(current_user),class: 'nav-link active' do %>
+    <i class="fas fa-user"></i> マイページ
+  <% end %>
+</li>
+<li>
+  <%= link_to new_post_path,class: 'nav-link active' do %>
+    <i class="fas fa-plus-circle"></i> 新規記事投稿
+  <% end %>
+</li>
+<li>
+  <%= link_to notifications_path, class: 'nav-link active' do %>
+    <i class="fas fa-bell faa-tada animated-hover"></i> 通知
+    <% if unchecked_notifications.any? %>
+      <i class="fas fa-circle" style="color: gold;"></i>
+    <% end %>
+  <% end %>
+</li>
+<li>
+  <%= link_to destroy_user_session_path,class: 'nav-link active', method: :delete do %>
+    <i class="fas fa-sign-out-alt faa-passing animated-hover"></i> ログアウト
+  <% end %>
+</li>
+<li>
+  <%= link_to about_path,class: 'nav-link active' do %>
+    <i class="fas fa-question-circle faa-pulse animated-hover"></i> 当サイトについて
+  <% end %>
+</li>

--- a/app/views/layouts/_user_signed_out_bar.html.erb
+++ b/app/views/layouts/_user_signed_out_bar.html.erb
@@ -1,0 +1,16 @@
+<li>
+  <%= link_to new_user_registration_path,class: 'nav-link active' do %>
+    <i class="fas fa-user-plus"></i> 新規登録
+  <% end %>
+</li>
+<li>
+  <%= link_to new_user_session_path,class: 'nav-link active' do %>
+    <i class="fas fa-sign-in-alt"></i> ログイン
+  <% end %>
+</li>
+<li><%= link_to 'ゲストログイン(閲覧用)',guest_sign_in_users_path, class: "guest-login nav-link active", method: :post %></li>
+<li>
+  <%= link_to about_path,class: 'nav-link active' do %>
+    <i class="fas fa-question-circle"></i> 当サイトについて
+  <% end %>
+</li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,55 +23,11 @@
         <div class="collapse navbar-collapse" id="navbarTogglerDropdown">
           <ul class="navbar-nav ml-auto">
             <% if user_signed_in? %>
-              <li>
-                <%= link_to user_path(current_user),class: 'nav-link active' do %>
-                  <i class="fas fa-user"></i> マイページ
-                <% end %>
-              </li>
-              <li>
-                <%= link_to new_post_path,class: 'nav-link active' do %>
-                  <i class="fas fa-plus-circle"></i> 新規記事投稿
-                <% end %>
-              </li>
-              <li>
-                <%= link_to notifications_path, class: 'nav-link active' do %>
-                  <i class="fas fa-bell faa-tada animated-hover"></i> 通知
-                  <% if unchecked_notifications.any? %>
-                    <i class="fas fa-circle" style="color: gold;"></i>
-                  <% end %>
-                <% end %>
-              </li>
-              <li>
-                <%= link_to destroy_user_session_path,class: 'nav-link active', method: :delete do %>
-                  <i class="fas fa-sign-out-alt faa-passing animated-hover"></i> ログアウト
-                <% end %>
-              </li>
-              <li>
-                <%= link_to about_path,class: 'nav-link active' do %>
-                  <i class="fas fa-question-circle faa-pulse animated-hover"></i> 当サイトについて
-                <% end %>
-              </li>
+              <%= render "layouts/user_signed_in_bar" %>
             <% elsif admin_signed_in? %>
-              <li><%= link_to "ジャンル一覧", admin_genres_path,class: 'nav-link active' %></li>
-              <li><%= link_to "会員一覧", admin_root_path,class: 'nav-link active' %></li>
-              <li><%= link_to "ログアウト", destroy_admin_session_path,class: 'nav-link active', method: :delete %></li>
+              <%= render "layouts/admin_signed_in_bar" %>
             <% else %>
-              <li>
-                <%= link_to new_user_registration_path,class: 'nav-link active' do %>
-                  <i class="fas fa-user-plus"></i> 新規登録
-                <% end %>
-              </li>
-              <li>
-                <%= link_to new_user_session_path,class: 'nav-link active' do %>
-                  <i class="fas fa-sign-in-alt"></i> ログイン
-                <% end %>
-              </li>
-              <li><%= link_to 'ゲストログイン(閲覧用)',guest_sign_in_users_path, class: "guest-login nav-link active", method: :post %></li>
-              <li>
-                <%= link_to about_path,class: 'nav-link active' do %>
-                  <i class="fas fa-question-circle"></i> 当サイトについて
-                <% end %>
-              </li>
+              <%= render "layouts/user_signed_out_bar" %>
             <% end %>
           </ul>
         </div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,19 +1,19 @@
+<!--各フラッシュメッセージの表示用-->
 <% flash.each do |key, value| %>
     <p class="alert alert-<%= key %>">
       <%= value %>
     </p>
   <% end %>
-<!--各フラッシュメッセージの表示用-->
 
 <div class="container-field my-4">
   <div class="row mx-4">
     <div class="col-md-1">
-    <table border="1" width="120" height="150" class="table-warning">
-      <tr align="center">
+    <table class="genre-table">
+      <tr>
         <th>ジャンル検索</th>
       </tr>
       <tr>
-        <td class="font-weight-bold">
+        <td>
           <% @genres.each do |genre| %>
             <%= link_to genre.name, search_genre_path("search[value]": genre.id) %>(<%= genre.posts.showable.count %>)<br />
           <% end %>

--- a/app/views/public/post_comments/_comment.html.erb
+++ b/app/views/public/post_comments/_comment.html.erb
@@ -66,8 +66,8 @@
   <% end %>
 
 <script>
-$('#evaluate_stars').empty();
 // ブラウザバックで星が増えるエラー回避のために記述
+$('#evaluate_stars').empty();
   $('#evaluate_stars').raty({
     starOn: "<%= asset_path('star-on.png') %>",
     starOff: "<%= asset_path('star-off.png') %>",
@@ -76,8 +76,8 @@ $('#evaluate_stars').empty();
     half: true,
   });
 
-$('.post_comment-rate').empty();
 // ブラウザバックで星が増えるエラー回避のために記述
+$('.post_comment-rate').empty();
   $('.post_comment-rate').raty({
     readOnly: true,
     starOn: "<%= asset_path('star-on.png') %>",

--- a/app/views/public/posts/edit.html.erb
+++ b/app/views/public/posts/edit.html.erb
@@ -80,8 +80,8 @@
 </div>
 
 <script>
-$('.post-rate').empty();
 // ブラウザバックで星が増えるエラー回避のために記述
+$('.post-rate').empty();
   $('.post-rate').raty({
     starOn: "<%= asset_path('star-on.png') %>",
     starOff: "<%= asset_path('star-off.png') %>",

--- a/app/views/public/posts/new.html.erb
+++ b/app/views/public/posts/new.html.erb
@@ -1,8 +1,14 @@
 <% if @post.errors.any? %>
-  <%= @post.errors.count %>件のエラーが発生しました<br/>
-  <% @post.errors.full_messages.each do |message| %>
-    <%= message %>
-  <% end %>
+  <div id="error_explanation">
+    <h2>
+      <%= @post.errors.count %>件のエラーが発生しました<br/>
+    </h2>
+    <ul>
+      <% @post.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
 <% end %>
 <div class="container_field">
   <div class="row ml-5">

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -117,7 +117,7 @@
 </div>
 
   <% else %>
-    <p>本記事の非公開です。投稿主様のみご確認いただけます。</p>
+    <p>本記事の内容は非公開です。投稿主様のみご確認いただけます。</p>
   <% end %>
 
 <% else %>
@@ -126,8 +126,8 @@
 
 
 <script>
-$('.post-rate').empty();
 // ブラウザバックで星が増えるエラー回避のために記述
+$('.post-rate').empty();
   $('.post-rate').raty({
     readOnly: true,
     starOn: "<%= asset_path('star-on.png') %>",

--- a/app/views/public/relationships/followers.html.erb
+++ b/app/views/public/relationships/followers.html.erb
@@ -1,5 +1,5 @@
-<h2>こちらの方々からフォローされています</h2>
 <% if @users.exists? %>
+<h2><%= @user.name %> 様はこちらの方々からフォローされています</h2>
 <table class="table search-result">
   <thead>
     <tr>
@@ -13,5 +13,5 @@
   </tbody>
 </table>
 <% else %>
-  <p>まだフォローされていません</p>
+  <h3><%= @user.name %> 様はまだフォローされていません</h3>
 <% end %>

--- a/app/views/public/relationships/followings.html.erb
+++ b/app/views/public/relationships/followings.html.erb
@@ -1,5 +1,5 @@
-<h2>こちらの方々をフォローしています</h2>
 <% if @users.exists? %>
+<h2><%= @user.name %> 様はこちらの方々をフォローしています</h2>
 <table class="table search-result">
   <thead>
     <tr>
@@ -13,5 +13,5 @@
   </tbody>
 </table>
 <% else %>
-  <p>まだ誰もフォローしていないようです</p>
+  <h3><%= @user.name %> 様はまだ誰もフォローしていないようです</h3>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,24 @@ ja:
     formats:
       default: "%Y/%m/%d %H:%M"
   activerecord:
+    models:
+      user: ユーザー
+      post: 投稿
+      genre: ジャンル
+    attributes:
+      user:
+        email: メールアドレス
+        name: ニックネーム
+        password: パスワード
+        our_answers_id: ユーザーＩＤ
+      post:
+        reference_url: 参考記事URL
+        title: 投稿タイトル
+        body: 投稿内容詳細
+        genre_id: ジャンル
+        genre: ジャンル
+      genre:
+        name: ジャンル
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'


### PR DESCRIPTION
・ja.ymlにuser、post、genreモデルのカラム名の日本語表記を追記
・ヘッダー部分の記述を部分テンプレート化
・ｐｏｓｔのエラーバリデーションのレイアウト調整
・ジャンル検索テーブルのHTMLでのレイアウトの装飾をCSSで書き換え